### PR TITLE
rgee version 1.0.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgee
 Title: R Bindings for Calling the 'Earth Engine' API
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: 
     c(person(given = "Cesar",
              family = "Aybar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@ vignette: >
   %\VignetteIndexEntry{NEWS}
   %\VignetteEncoding{UTF-8}
 ---
+# rgee 1.0.5
+- ee_utils_add_text_to_gif
+- ee_utils_create_manifest
+- New | operator inspirated in mapview 2.9.0 (now with adaptive resampling <3)
+- Fix typos.
+
 # rgee 1.0.4
 - Add `ee_help` a new Rstudio addins that mimics the help Rstudio interface (F1).
 - Fix a bug that makes that `ee_as_sf` only supports `GeoJSON` format.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ status](https://www.r-pkg.org/badges/version/rgee)](https://cran.r-project.org/p
 `rgee` is a binding package for calling [Google Earth Engine
 API](https://developers.google.com/earth-engine/) from within R.
 Additionally, several functions have been implemented to make simple the connection with the R spatial ecosystem. The current version of rgee has been built considering the 
-[earthengine-api 0.1.229](https://pypi.org/project/earthengine-api/0.1.229/).
+[earthengine-api 0.1.230](https://pypi.org/project/earthengine-api/0.1.230/).
 **Note that access to Google Earth Engine is only available to [registered users](https://earthengine.google.com/)**.
 
 


### PR DESCRIPTION
In this new version we change a little the I/O functionality to make more compressible the upload of raster and sf objects through GCS. 