### PR TITLE
Support non-GUI ee_Initialize()

### DIFF
--- a/R/ee_Initialize.R
+++ b/R/ee_Initialize.R
@@ -304,7 +304,12 @@ ee_create_credentials_earthengine <- function(email_clean, display) {
     earthengine_auth <- ee$oauth$get_authorization_url(code_challenge)
     # Display URL?
     if (display) {
-      message("\n", earthengine_auth)
+      message("\n To authorize access needed by Earth Engine, open the following URL in a web browser and follow the instructions: \n \n", earthengine_auth, "\n \n The authorization workflow will generate a code, which you should paste in the box below")
+      auth_code <- readline("Enter Earth Engine Authentication: ")
+      token <- ee$oauth$request_token(auth_code, code_verifier)
+      credential <- sprintf('{"refresh_token":"%s"}', token)
+      write(credential, main_ee_credential)
+      write(credential, user_ee_credential)
     }
     ee_save_eecredentials(
       url = earthengine_auth,


### PR DESCRIPTION
Added interactive OAuth for `ee_Initialize(display =  TRUE)` in line 307 for users connectig to a remote server which lacks a browser definition (as per the error trace: `Error in browseURL(url): 'browser' must be a non-empty character string`). 

This way rgee outputs the `earthengine_auth`, which the user can copy to a GUI browser and then input the token and store it (as in `ee_save_eecredentials()`)