### PR TITLE
trigger informative error in `local_to_gcs`

### DIFF
--- a/R/utils-upload.R
+++ b/R/utils-upload.R
@@ -32,7 +32,7 @@ local_to_gcs <- function(x,
     stop("Cloud Storage bucket was not defined")
   }
 
-  if (is.na(getOption("rgee.gcs.auth"))) {
+  if (is.na(getOption("rgee.gcs.auth")) || is.null(getOption("rgee.gcs.auth"))) {
     stop(
       "Google Cloud Storage credentials were not loaded.",
       ' Run ee_Initialize(..., gcs = TRUE)',


### PR DESCRIPTION
On my system, `getOption("rgee.gcs.auth")` returns `NULL`, which failed to trigger the informative error message and instead errored opaquely with 
```
Error in if (is.na(getOption("rgee.gcs.auth"))) { : 
  argument is of length zero
```

## Session Info
```
R version 4.0.2 (2020-06-22)
Platform: x86_64-apple-darwin17.0 (64-bit)
Running under: macOS  10.16

Matrix products: default
LAPACK: /Library/Frameworks/R.framework/Versions/4.0/Resources/lib/libRlapack.dylib

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] rgee_1.1.0                stars_0.4-1               sf_1.0-4                  abind_1.4-5               raster_3.5-2             
[6] sp_1.4-6                  ebirdst_0.3.3             googleCloudStorageR_0.6.0

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.7             lattice_0.20-41        prettyunits_1.1.1      class_7.3-17           ps_1.6.0               assertthat_0.2.1      
 [7] rprojroot_2.0.2        digest_0.6.28          utf8_1.2.2             mime_0.12              R6_2.5.1               e1071_1.7-9           
[13] httr_1.4.2             pillar_1.6.4           rlang_0.4.12           curl_4.3.2             rstudioapi_0.13        googleAuthR_1.4.0.9000
[19] callr_3.7.0            Matrix_1.2-18          reticulate_1.15        rgdal_1.5-27           stringr_1.4.0          htmlwidgets_1.5.4     
[25] proxy_0.4-26           compiler_4.0.2         httpuv_1.6.3           pkgconfig_2.0.3        askpass_1.1            pkgbuild_1.2.0        
[31] htmltools_0.5.2        openssl_1.4.5          tidyselect_1.1.1       tibble_3.1.6           codetools_0.2-16       fansi_0.5.0           
[37] crayon_1.4.2           dplyr_1.0.7            withr_2.4.3            later_1.3.0            wk_0.5.0               rappdirs_0.3.3        
[43] grid_4.0.2             jsonlite_1.7.2         lwgeom_0.2-3           lifecycle_1.0.1        DBI_1.1.1              magrittr_2.0.1        
[49] units_0.7-2            KernSmooth_2.23-17     zip_2.2.0              stringi_1.7.5          cli_3.1.0              cachem_1.0.6          
[55] fs_1.5.0               promises_1.2.0.1       remotes_2.3.0          leaflet_2.0.3          ellipsis_0.3.2         vctrs_0.3.8           
[61] generics_0.1.1         s2_1.0.7               tools_4.0.2            glue_1.5.0             purrr_0.3.4            crosstalk_1.1.1       
[67] processx_3.5.2         parallel_4.0.2         fastmap_1.1.0          yaml_2.2.1             gargle_1.2.0           terra_1.4-22          
[73] classInt_0.4-3         memoise_2.0.1          usethis_1.6.1    
```