### PR TITLE
Alternative proposal to handle maxFeatures<5000, see issue #229

### DIFF
--- a/R/ee_as_sf.R
+++ b/R/ee_as_sf.R
@@ -145,12 +145,6 @@ ee_as_sf <- function(x,
   #check packages
   ee_check_packages("ee_as_sf", c("sf", "geojsonio"))
 
-
-  # Change low maxFeature values.
-  if (maxFeatures < 5000) {
-    maxFeatures <- 5000
-  }
-
   # Is  a geometry, feature, or fc?
   sp_eeobjects <- ee_get_spatial_objects('Table')
   if (!any(class(x) %in% sp_eeobjects)) {
@@ -286,8 +280,8 @@ ee_fc_to_sf_getInfo_batch <- function(x_fc, dsn, maxFeatures, overwrite, quiet) 
   # using getInfo).
   fc_size <- 5000
 
-  # If maxFeatures is greather than 5000 estimate the number of elements.
-  if (maxFeatures > 5000) {
+  # If maxFeatures is different than 5000 estimate the number of elements.
+  if (maxFeatures != 5000) {
     if (!quiet) {
       cat("Number of features: Calculating ...")
     }


### PR DESCRIPTION
This is regarding issue #229, suggesting to simply recompute the size of the collection as soon as the user changes the `maxFeatures` parameter (i.e. doesn't leave it to 5000). This seems to be more in line with the documentation, and avoid silently changing back the parameter to 5000. 

What do you think?