### PR TITLE
Introduce new argument in ee_monitoring: max_attempts

### DIFF
--- a/man/ee_monitoring.Rd
+++ b/man/ee_monitoring.Rd
@@ -4,7 +4,13 @@
 \alias{ee_monitoring}
 \title{Monitoring Earth Engine task progress}
 \usage{
-ee_monitoring(task, task_time = 5, eeTaskList = FALSE, quiet = FALSE)
+ee_monitoring(
+  task,
+  task_time = 5,
+  eeTaskList = FALSE,
+  quiet = FALSE,
+  max_attempts = Inf
+)
 }
 \arguments{
 \item{task}{List generated after a task is started (i.e., after run
@@ -17,6 +23,8 @@ task started.}
 listed.}
 
 \item{quiet}{Logical. Suppress info message}
+
+\item{max_attempts}{Number of times to monitor the tasks before ending.}
 }
 \value{
 An \code{ee$batch$Task} object with a state "COMPLETED" or "FAILED"


### PR DESCRIPTION
This is a suggestion to add a new argument `max_attempts` to ee_monitoring, after which `ee_monitoring` would stop if the task is still uncompleted. The problem with the current version is that the function could run for hours without being interrupted, and furthermore that interrupting it requires brute force. 

I've set the argument `max_attempts=Inf` to reproduce current behaviour, but it would be probably good to have a more reasonable default, like 10, or with respect to the task_time, say by default not more than 5 minutes (300/task_time)?

This argument could also serve for a quite similar function, something like `ee_check_task_status`, that only checks the status once?

```
library(rgee)
ee_Initialize()

ee_check_task_status <- function(task, quiet = FALSE) {
  ee_monitoring(task, task_time = 1, eeTaskList = FALSE, quiet = quiet, max_attempts = 1)
}
```