### PR TITLE
updated ee_check_python() to use compareVersion()

### DIFF
--- a/R/ee_check.R
+++ b/R/ee_check.R
@@ -47,7 +47,7 @@ ee_check <- function(user = NULL, quiet = FALSE) {
 ee_check_python <- function(quiet = FALSE) {
   python_test <- py_available(initialize = TRUE)
   if (python_test) {
-    py_version <- as.numeric(py_discover_config()[["version"]])
+    py_version <- py_discover_config()[["version"]]
     if (!quiet) {
       cat_line(
         blue(symbol[["circle_filled"]]),
@@ -66,7 +66,9 @@ ee_check_python <- function(quiet = FALSE) {
       "rgee::ee_Initialize(). For more details run reticulate::py_available()"
     )
   }
-  if (py_version < 3.5) stop("rgee needs Python 3.5 >=")
+  if (utils::compareVersion(py_version, "3.5") == -1) {
+    stop("rgee needs Python 3.5 >=")
+  }
   return(invisible(TRUE))
 }
 


### PR DESCRIPTION
Here I propose a change to how the python version is checked in `ee_check_python()`. 

While using python version 3.10, `ee_check()` would throw an error (""rgee needs Python 3.5 >=") for me. 

The issue is that, for example ' as.numeric(py_discover_config()[["version"]])', converts 3.10 to 3.1.  (The same problem would occur for version 3.20, 3.30 etc. which are also greater than 3.5).

I propose to keep py_version as a string and then compare it to version '3.5' using the compareVersion() function.