### PR TITLE
commented out prefixing of assetId with "projects/earthegine-legacy/assets/"

### DIFF
--- a/R/utils-upload.R
+++ b/R/utils-upload.R
@@ -481,7 +481,8 @@ ee_utils_create_manifest_image <- function(gs_uri,
   )
 
   # Create a name
-  name <- sprintf("projects/earthengine-legacy/assets/%s", assetId)
+  # name <- sprintf("projects/earthengine-legacy/assets/%s", assetId)
+  name <- assetId
 
   # from R date to JS timestamp: time_start + time_end
   time_start <- rdate_to_eedate(start_time, timestamp = TRUE)
@@ -576,7 +577,8 @@ ee_utils_create_manifest_table <- function(gs_uri,
   )
 
   # Create a name
-  name <- sprintf("projects/earthengine-legacy/assets/%s", assetId)
+  # name <- sprintf("projects/earthengine-legacy/assets/%s", assetId)
+  name <- assetId
 
   # Creating tileset
   sources <- list(


### PR DESCRIPTION
Hi @saybar et al,

Thank you for this awesome package! 📦 🚀 

I was having trouble uploading vector `sf` polygons into Earth Engine assets and noticed some odd prefixing of the proposed assetId with `"projects/earthengine-legacy/assets/"`, so I commented that out, and it now works. 

Example with my own user-specific paths:

```
devtools::install_github("ecoquants/offhabr")
if (!require(librarian))
  install.packages("librarian")
librarian::shelf(
  devtools, sf, rgee)
ee_Initialize(gcs = TRUE)

ee_x <- st_read(system.file("shape/nc.shp", package = "sf"))

fc_zones <- rgee::sf_as_ee(
  ee_x, 
  via        = "gcs_to_asset",
  assetId    = "projects/ee-offhab/assets/fc_nc",
  bucket     = "offhab_lyrs",
  proj       = "EPSG:4326",
  monitoring = T,
  quiet      = F)
```