### PR TITLE
Altered ee_extract to accept sf object with any geometry column name …

### DIFF
--- a/R/ee_extract.R
+++ b/R/ee_extract.R
@@ -196,7 +196,7 @@ ee_extract <- function(x,
     #   message("NOTE: y is an sf object, running 'sf_as_ee(y$geometry)' to ",
     #           "convert in an ee$FeatureCollection object.")
     # }
-    ee_y <- sf_as_ee(y[["geometry"]], quiet = TRUE)
+    ee_y <- sf_as_ee(y[[attr(y, "sf_column")]], quiet = TRUE)
   } else if(any("sfc" %in%  class(y))) {
     sf_y <- sf::st_sf(id = seq_along(y), geometry = y)
     # if (!quiet) {


### PR DESCRIPTION
…(not just geometry)

sf object geometry column can take different names (i.e. geom, geoms, geometry, etc.). This is a simple fix to avoid an error in ee_extract when sf object is not "geometry"