### PR TITLE
Updated ee_check_init() to compare earthengine-api version using

### DIFF
--- a/R/utils-auth.R
+++ b/R/utils-auth.R
@@ -24,7 +24,7 @@ ee_check_init <- function() {
   earthengine_version <- ee_utils_py_to_r(ee_utils$ee_getversion())
 
   # is earthengine-api greater than 0.1.317?
-  if (as.numeric(gsub("\\.","",earthengine_version)) < 01317) {
+  if (numeric_version(earthengine_version) < numeric_version("0.1.317")) {
     warning(
       "Update your earthengine-api installations to v0.1.317 or greater. ",
       "Earlier versions are not compatible with recent ",


### PR DESCRIPTION
In `ee_check_init()`, we verify that the earthengine-api version is compatible with rgee, specifically ensuring it's not newer than version 0.1.317. However, the latest version of earthengine-api (1.2.0) is incorrectly flagged as outdated due to the current comparison method.

To address this issue, I updated the comparison approach to use `numeric_version()`. This fix prevents unnecessary warnings from being triggered, such as when calling `ee_clean_user_credentials()` with the latest earthengine-api version.