### PR TITLE
Fix issue ee_check_python(): Error in strsplit(a, "[.-]"): non-character argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgee
 Title: R Bindings for Calling the 'Earth Engine' API
-Version: 1.1.7
+Version: 1.1.7.000009
 Authors@R: 
     c(person(given = "Cesar",
              family = "Aybar",

--- a/R/ee_check.R
+++ b/R/ee_check.R
@@ -78,7 +78,7 @@ ee_check_python <- function(quiet = FALSE) {
       "rgee::ee_Initialize(). For more details run reticulate::py_available()"
     )
   }
-  if (utils::compareVersion(py_version, "3.5") == -1) {
+  if (utils::compareVersion(as.character(py_version), "3.5") == -1) {
     stop("rgee needs Python 3.5 >=")
   }
   return(invisible(TRUE))


### PR DESCRIPTION
should fix #392 , runs now without error:

``` r
library(rgee)
packageVersion("rgee")
#> [1] '1.1.7.9'
ee_check_python()
#> ◉  Python version
#> ✔ [Ok] /home/xxx/.cache/R/reticulate/uv/cache/archive-v0/hVk2jz0ebnIx6PZclvvcc/bin/python v3.11
```

<sup>Created on 2025-06-30 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
