### PR TITLE
fix reduceRegions error

### DIFF
--- a/R/ee_extract.R
+++ b/R/ee_extract.R
@@ -235,7 +235,7 @@ ee_extract <- function(x,
   # triplets save info about the value, the row_id (ee_ID) and col_id (imageId)
   create_tripplets <- function(img) {
     img_reduce_regions <- ee$Image$reduceRegions(
-      image = img,
+      img,
       collection = ee_y,
       reducer = fun,
       scale = scale,


### PR DESCRIPTION
```r
r = ee_extract(col, sp, via = "getInfo", lazy = FALSE, scale = 500)

Error in ee$Image$reduceRegions(image = img, collection = ee_y, reducer = fun,  : 
  RuntimeError: unused argument (image = img)
Run `reticulate::py_last_error()` for details.
```

```python
ee$Image$reduceRegions
<function Image.reduceRegions at 0x0000025DAA66E770>
 signature: (
   self, 
   collection: '_arg_types.FeatureCollection', 
   reducer: '_arg_types.Reducer', 
   scale: '_arg_types.Number | None' = None, 
   crs: '_arg_types.Projection | None' = None, 
   crsTransform: '_arg_types.List | None' = None, 
   tileScale: '_arg_types.Number | None' = None, 
   maxPixelsPerRegion: '_arg_types.Integer | None' = None
) -> 'featurecollection.FeatureCollection'
```

This is a small bug. `image` is not a keyword Argument. 


